### PR TITLE
Handle quantile smaller than 1/N

### DIFF
--- a/demo/quantiles.r
+++ b/demo/quantiles.r
@@ -40,8 +40,12 @@ comm.quantile <- function(x, probs=seq(0, 1, 0.25), na.rm=FALSE, names=TRUE,
     ## TODO are there better bounds?
     if(i > 1) q_lo <- q_val[i - 1]
     if(verbose > 1) comm.cat(comm.rank(), "lo hi:", q_lo, q_hi, "\n")
-    q <- uniroot(f.quant, c(q_lo, q_hi), prob=probs[i])
-    q_val <- c(q_val, q$root)
+    if (probs[i] <= 1.0/N){
+      q_val <- c(q_val, q_lo);
+    }else{
+      q <- uniroot(f.quant, c(q_lo, q_hi), prob=probs[i])
+      q_val <- c(q_val, q$root)
+    }
   }
   names(q_val) <- q_names
   q_val

--- a/demo/quantiles.r
+++ b/demo/quantiles.r
@@ -43,8 +43,13 @@ comm.quantile <- function(x, probs=seq(0, 1, 0.25), na.rm=FALSE, names=TRUE,
     if (probs[i] <= 1.0/N){
       q_val <- c(q_val, q_lo);
     }else{
-      q <- uniroot(f.quant, c(q_lo, q_hi), prob=probs[i])
-      q_val <- c(q_val, q$root)
+      sm = allreduce(sum(x <= probs[i], na.rm=TRUE), op="sum");
+      if (sm == 0){
+        q_val <- c(q_val, q_lo);
+      }else{
+        q <- uniroot(f.quant, c(q_lo, q_hi), prob=probs[i])
+        q_val <- c(q_val, q$root)
+      }
     }
   }
   names(q_val) <- q_names


### PR DESCRIPTION
Uniroot fails if zero is not in the interval.

Perhaps this can be improved by interpolating between smallest and next smallest value.